### PR TITLE
Ilphat/fpg 84

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,15 +28,27 @@ services:
             - "${SERVER_PORT}:${SERVER_PORT}"
         environment:
           SERVER_PORT: ${SERVER_PORT}
-
     postgres:
-      image: postgres:14
-      ports:
-        - "${POSTGRES_PORT}:${POSTGRES_PORT}"
-      environment:
-        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-        POSTGRES_USER: ${POSTGRES_USER}
-        POSTGRES_DB: ${POSTGRES_DB}
-      volumes:
-        - ./tmp/pgdata:/var/lib/postgresql/data
-
+        container_name: db
+        image: postgres:15.3
+        restart: always
+        ports:
+          - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+        environment:
+          POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+          POSTGRES_USER: ${POSTGRES_USER}
+          POSTGRES_DB: ${POSTGRES_DB}
+        volumes:
+          - ./tmp/pgdata:/var/lib/postgresql/data
+    pgadmin:
+        container_name: pgadmin
+        image: dpage/pgadmin4:7.1
+        restart: always
+        depends_on:
+          - postgres
+        environment: 
+          PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+          PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+          PGADMIN_LISTEN_PORT: ${PGADMIN_LISTEN_PORT}
+        ports:
+          - "${PGADMIN_PORT}:${PGADMIN_LISTEN_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
           SERVER_PORT: ${SERVER_PORT}
 
     postgres:
-      image: postgres:14     
+      image: postgres:14
       ports:
         - "${POSTGRES_PORT}:${POSTGRES_PORT}"
       environment:


### PR DESCRIPTION
настроен docker для postgres и pdadmin
необходимо добавить .env файл рядом с docker-compose.yml и указать данные для postgres и pgadmin.
POSTGRES_USER={user}
POSTGRES_PASSWORD={password}
POSTGRES_DB={name of DB}
POSTGRES_PORT=5432

PGADMIN_DEFAULT_EMAIL={email}
PGADMIN_DEFAULT_PASSWORD={password}
PGADMIN_PORT=8080
PGADMIN_LISTEN_PORT=80

Для создания и запуска контейнеров: docker compose up postgres pgadmin
Для  остановки и удаления контейнеров: docker compose down

pgadmin должен запуститься на localhost:8080

для подключения к бд на главной странице нажать 'Add New Server'.
во вкладке 'General' в поле Name вводим любое название.
во вкладке 'Connection' вводим в поля 
'Host name/adress' = postgres,  
Maintenance Database={POSTGRES_DB}
Username={POSTGRES_USER}, 
Password={POSTGRES_PASSWORD}
![pgadmin](https://github.com/fastPaws-game/fastPaws/assets/90051828/73def649-d297-43d3-bd21-0d5bea3ffcc7)
![pgadmin2](https://github.com/fastPaws-game/fastPaws/assets/90051828/7a95ac6b-2502-40a6-94b4-aa55122e55c5)
